### PR TITLE
patch: check if window is undefined to support SSR

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,8 @@ const initialState = {
   messages: [],
 };
 
-const supportsBroadcastAPI = (() => window && window.BroadcastChannel)();
+const supportsBroadcastAPI =
+  typeof window !== "undefined" && "BroadcastChannel" in window;
 
 function useBrowserContextCommunication(channelName) {
   if (channelName === undefined) {


### PR DESCRIPTION
I was getting errors with Next.js when using this because window is undefined when server rendering. This adds a simple check that cleared the issue up for me